### PR TITLE
Correct prev link on resources page

### DIFF
--- a/src/app/docs/resources/page.mdx
+++ b/src/app/docs/resources/page.mdx
@@ -47,8 +47,8 @@ For brutalist icons (stars, etc.), there are many resources, but I particularly 
 
 <Pagination
   prev={{
-    name: 'Colors',
-    path: '/docs/colors',
+    name: 'Styling',
+    path: '/docs/styling',
   }}
   next={{
     name: 'React',


### PR DESCRIPTION
Currently pointing to a 404 /colors/ page, when the previous as per nav is the styling page :)