### PR TITLE
removed react-icons from components and added lucide-react icons

### DIFF
--- a/src/components/react/components/Accordion.tsx
+++ b/src/components/react/components/Accordion.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ClassValue } from 'clsx'
-import { FiPlus } from 'react-icons/fi'
+import { ChevronDown } from 'lucide-react'
 
 import { useEffect, useRef, useState } from 'react'
 
@@ -41,7 +41,7 @@ export default function Accordion({ question, answer, className }: Props) {
         }}
       >
         {question}
-        <FiPlus className="sm:ml-4 ml-3 sm:min-h-[24px] sm:min-w-[24px] group-data-[state=open]:rotate-45 group-data-[state=closed]:0 min-h-[18px] min-w-[18px] transition-transform ease-in-out" />
+        <ChevronDown className="sm:ml-4 ml-3 sm:min-h-[24px] sm:min-w-[24px] group-data-[state=open]:rotate-180 group-data-[state=closed]:0 min-h-[18px] min-w-[18px] transition-transform ease-in-out" />
       </button>
       <div
         ref={contentRef}

--- a/src/components/react/components/Alert.tsx
+++ b/src/components/react/components/Alert.tsx
@@ -1,5 +1,5 @@
 import { ClassValue } from 'clsx'
-import { TbAlertOctagonFilled } from 'react-icons/tb'
+import { CircleAlert } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 
@@ -14,11 +14,11 @@ export default function Alert({
     <div
       role="alert"
       className={cn(
-        'flex items-center justify-center rounded-base border-2 border-black bg-main py-4 sm:px-8 sm:py-5 px-4 font-base text-sm md:text-base shadow-base',
+        'flex items-center justify-center rounded-base border-2 border-black bg-main py-4 sm:px-8 sm:py-5 px-4 font-heading text-sm md:text-base shadow-base',
         className,
       )}
     >
-      <TbAlertOctagonFilled className="mr-3 md:min-h-[24px] md:min-w-[24px] min-h-[18px] min-w-[18px]" />
+      <CircleAlert className="mr-3 md:min-h-[24px] md:min-w-[24px] min-h-[18px] min-w-[18px]" />
       {message}
     </div>
   )

--- a/src/components/react/components/Checkbox.tsx
+++ b/src/components/react/components/Checkbox.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { MdCheck } from 'react-icons/md'
+import { Check } from 'lucide-react'
 
 import { useState } from 'react'
 
@@ -17,7 +17,7 @@ export default function Checkbox({ item }: { item: string }) {
       aria-checked={isChecked}
     >
       <div className="mr-2.5 grid h-5 w-5 place-items-center bg-white outline outline-2 outline-black">
-        {isChecked && <MdCheck className="h-4 w-4" />}
+        {isChecked && <Check className="h-4 w-4" />}
       </div>
       <p>{item}</p>
     </button>

--- a/src/components/react/components/Dropdown.tsx
+++ b/src/components/react/components/Dropdown.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FaChevronDown } from 'react-icons/fa'
+import { ChevronDown } from 'lucide-react'
 
 import { useState } from 'react'
 
@@ -31,9 +31,9 @@ export default function Dropdown({
       >
         <div className="mx-auto flex items-center">
           {text}
-          <FaChevronDown
+          <ChevronDown
             className={
-              'ml-3 h-4 w-4 transition-transform group-data-[state=open]:rotate-180 group-data-[state=closed]:rotate-0 ease-in-out'
+              'ml-2 h-5 w-5 transition-transform group-data-[state=open]:rotate-180 group-data-[state=closed]:rotate-0 ease-in-out'
             }
           />
         </div>

--- a/src/components/react/components/Modal.tsx
+++ b/src/components/react/components/Modal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
+import { X } from 'lucide-react'
 import ReactDom from 'react-dom'
-import { MdClose } from 'react-icons/md'
 
 import React, { useEffect, useState } from 'react'
 
@@ -42,7 +42,7 @@ export default function Modal({ active, setActive, children }: Props) {
         className="relative flex w-[300px] group-data-[visible=true]:opacity-100 group-data-[visible=true]:visible group-data-[visible=false]:opacity-0 group-data-[visible=false]:invisible flex-col items-center justify-center rounded-base border-2 border-black bg-main p-10 pt-12 font-base shadow-base transition-all duration-300"
       >
         <button onClick={closeModal}>
-          <MdClose className="absolute right-3 top-3 h-6 w-6" />
+          <X className="absolute right-3 top-3 h-6 w-6" />
         </button>
         {children}
         <button

--- a/src/components/react/components/Select.tsx
+++ b/src/components/react/components/Select.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FaChevronDown } from 'react-icons/fa'
+import { ChevronDown } from 'lucide-react'
 
 import { useState } from 'react'
 
@@ -32,9 +32,9 @@ export default function Select({ items }: { items: string[] }) {
       >
         <div className="mx-auto flex items-center">
           {selectedItem === null ? 'Select' : selectedItem}
-          <FaChevronDown
+          <ChevronDown
             className={
-              'ml-3 h-4 w-4 transition-transform group-data-[state=open]:rotate-180 group-data-[state=closed]:rotate-0 ease-in-out'
+              'ml-2 h-5 w-5 transition-transform group-data-[state=open]:rotate-180 group-data-[state=closed]:rotate-0 ease-in-out'
             }
           />
         </div>

--- a/src/markdown/react/installation/Installation.tsx
+++ b/src/markdown/react/installation/Installation.tsx
@@ -8,7 +8,7 @@ import Tabs from '@/components/react/components/Tabs'
 export default function Installation() {
   const packageManagers = ['npm', 'yarn', 'pnpm', 'bun']
 
-  const packages = 'clsx tailwind-merge react-icons'
+  const packages = 'clsx tailwind-merge lucide-react'
 
   const code: {
     [key in (typeof packageManagers)[number]]: string


### PR DESCRIPTION
Shadcn uses `lucide-react` icons so I switched to them, so it's better if someone uses both react and shadcn components (user doesn't have to install both `lucide-react` and `react-icons`, but only `lucide-react`)