### PR TITLE
apply theme background color

### DIFF
--- a/src/app/styling/styling.tsx
+++ b/src/app/styling/styling.tsx
@@ -250,7 +250,7 @@ export default function Styling() {
   
 @layer base {
   body {
-    @apply text-foreground font-base;
+    @apply text-foreground font-base bg-background;
   }
 
   h1, h2, h3, h4, h5, h6{


### PR DESCRIPTION
When you choose a color on the styling page the components and background colors change accordingly. However when you copy the theme into your globals.css in your own app, the background color is missing.